### PR TITLE
chore: upgrade runtime to 2.1.16

### DIFF
--- a/cf-default-app-dotnetcore.csproj
+++ b/cf-default-app-dotnetcore.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>cf-default-app-dotnetcore</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>cf-default-app-dotnetcore</PackageId>
-    <RuntimeFrameworkVersion>2.0.7</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.1.16</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Runtime 2.0.7 is no longer supported:
  **ERROR** Unable to install dotnet-runtime: dependency dotnet-runtime 2.0.7 not found
  Failed to compile droplet: Failed to run finalize script: exit status 12