### PR TITLE
chore: upgrade runtime to 2.1.18

### DIFF
--- a/cf-default-app-dotnetcore.csproj
+++ b/cf-default-app-dotnetcore.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>cf-default-app-dotnetcore</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>cf-default-app-dotnetcore</PackageId>
-    <RuntimeFrameworkVersion>2.1.16</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.1.18</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
runtime 2.1.16 no longer builds with the latest Dotnet Buildpack 